### PR TITLE
Use @types/vscode instead of deprecated vscode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,14 @@
 {
   "name": "vscode-variables",
-  "version": "0.1.2",
-  "lockfileVersion": 1
+  "version": "0.1.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/vscode": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.54.0.tgz",
+      "integrity": "sha512-sHHw9HG4bTrnKhLGgmEiOS88OLO/2RQytUN4COX9Djv81zc0FSZsSiYaVyjNidDzUSpXsySKBkZ31lk2/FbdCg==",
+      "dev": true
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -3,10 +3,9 @@
   "version": "0.1.3",
   "description": "Replace VSCode predefined variables for extensions",
   "main": "index.js",
-  "peerDependencies": {
-    "vscode": "^1.1.37"
+  "devDependencies": {
+    "@types/vscode": "^1.54.0"
   },
-  "devDependencies": {},
   "author": "Dominic Vonk",
   "license": "MIT",
   "repository": {
@@ -15,5 +14,6 @@
   },
   "bugs": {
     "url": "https://github.com/DominicVonk/vscode-variables/issues"
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
See https://www.npmjs.com/package/vscode for deprecation warning. 

https://www.npmjs.com/package/@types/vscode is a drop-in replacement.