### PR TITLE
Support (Neo)Vim by coc.nvim

### DIFF
--- a/coc-variables/.gitignore
+++ b/coc-variables/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules
+.DS_Store

--- a/coc-variables/.npmignore
+++ b/coc-variables/.npmignore
@@ -1,0 +1,4 @@
+/*
+!/out/
+*.map
+!/prebuilds/

--- a/coc-variables/README.md
+++ b/coc-variables/README.md
@@ -1,0 +1,20 @@
+# Coc.nvim Predefined Variable Parser
+
+Ported from [vscode-variables](https://github.com/DominicVonk/vscode-variables).
+
+## Install
+
+- [coc-marketplace](https://github.com/fannheyward/coc-marketplace)
+- [npm](https://www.npmjs.com/package/coc-variables)
+- vim:
+
+```vim
+" command line
+CocInstall coc-variables
+" or add the following code to your vimrc
+let g:coc_global_extensions = ['coc-variables', 'other coc-plugins']
+```
+
+## Usage
+
+Refer [vscode-variables](https://github.com/DominicVonk/vscode-variables).

--- a/coc-variables/package.json
+++ b/coc-variables/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "coc-variables",
+  "version": "0.0.1",
+  "description": "Replace Coc.nvim predefined variables for extensions",
+  "scripts": {
+    "patch": "scripts/patch.sh ../src/*.ts",
+    "prepack": "npm run patch && npm run build",
+    "build": "tsc",
+    "test": "vitest run"
+  },
+  "files": [
+    "package.json",
+    "README.md",
+    "LICENSE.md",
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "coc.nvim": "^0.0.83-next.18",
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.4"
+  },
+  "author": "Dominic Vonk",
+  "license": "MIT",
+  "repository": {
+    "url": "https://github.com/DominicVonk/vscode-variables.git",
+    "type": "git"
+  },
+  "bugs": {
+    "url": "https://github.com/DominicVonk/vscode-variables/issues"
+  }
+}

--- a/coc-variables/scripts/patch.pl
+++ b/coc-variables/scripts/patch.pl
@@ -1,0 +1,2 @@
+#!/usr/bin/env -S perl -p
+s=//#==;

--- a/coc-variables/scripts/patch.sh
+++ b/coc-variables/scripts/patch.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$(dirname "$(readlink -f "$0")")")"
+
+for file; do
+  scripts/patch.pl "$file" | cpp -DHAVE_COC_NVIM -nostdinc -P -C -o"${file#*/}"
+done

--- a/coc-variables/src/.gitignore
+++ b/coc-variables/src/.gitignore
@@ -1,0 +1,2 @@
+/*
+!/.gitignore

--- a/coc-variables/tsconfig.json
+++ b/coc-variables/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../tsconfig",
+    "compilerOptions": {
+        "outDir": "dist",
+        "noImplicitAny": false
+    },
+    "include": [
+        "src/**/*"
+    ]
+}


### PR DESCRIPTION
Refer:
https://github.com/valentjn/vscode-ltex/blob/3d0cb8cd9b4d0dc8ef6c08a4f376767820678cf6/src/extension.ts#L8-L14

Difference is vscode-ltex/coc-ltex uses a customized python script
https://github.com/valentjn/vscode-ltex/blob/3d0cb8cd9b4d0dc8ef6c08a4f376767820678cf6/tools/patchForTarget.py
to patch code
we use c language macro preprocessor cpp

Can you add me to collaborators to maintain the support of coc.nvim?
And I want to add your npm account to collaborators of npm package of [coc-variables](https://www.npmjs.com/package/coc-variables) due to
most code comes from you.
TIA!
